### PR TITLE
Hardcode repository URL in fetch script

### DIFF
--- a/scripts/fetch-repo.sh
+++ b/scripts/fetch-repo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="${REPO_URL:?Set REPO_URL to the repository URL}"
+REPO_URL="https://github.com/niceash7789/AgentRepo.git"
 TARGET_DIR="${TARGET_DIR:-pnp-powershell-schemas}"
 
 if [ -d "$TARGET_DIR/.git" ]; then


### PR DESCRIPTION
## Summary
- Hardcode repository URL in `scripts/fetch-repo.sh` for `niceash7789/AgentRepo`

## Testing
- `TARGET_DIR=/tmp/test-repo bash scripts/fetch-repo.sh >/tmp/test-repo.log && tail -n 20 /tmp/test-repo.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab316bbbac832f9a9c79c88b731212